### PR TITLE
Fix auth response fields for integration tests

### DIFF
--- a/src/handlers/auth.go
+++ b/src/handlers/auth.go
@@ -42,12 +42,12 @@ func (h *Handler) Login(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"userId":        user.ID,
-		"userFirstName": user.FirstName,
-		"userLastName":  user.LastName,
-		"userEmail":     user.Email,
-		"accessToken":   accessToken,
-		"refreshToken":  refreshToken,
+		"id":           user.ID,
+		"firstName":    user.FirstName,
+		"lastName":     user.LastName,
+		"email":        user.Email,
+		"accessToken":  accessToken,
+		"refreshToken": refreshToken,
 	})
 }
 
@@ -90,9 +90,9 @@ func (h *Handler) AccessTokenByRefreshToken(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"accessToken":  accessToken,
-		"userId":       user.ID,
-		"userUsername": user.Username,
-		"userEmail":    user.Email,
+		"accessToken": accessToken,
+		"id":          user.ID,
+		"username":    user.Username,
+		"email":       user.Email,
 	})
 }


### PR DESCRIPTION
## Summary
- align login and refresh token responses with integration tests

## Testing
- `gofmt -w src/handlers/auth.go`
- `go test -tags=integration ./Test/integration` *(fails: requires network)*

------
https://chatgpt.com/codex/tasks/task_e_6863f9dcefa48330a3543e388fd5d17e