### PR TITLE
Fix variable substitution for integration tests

### DIFF
--- a/Test/integration/steps.go
+++ b/Test/integration/steps.go
@@ -211,6 +211,9 @@ func theJSONResponseShouldContain(field, value string) error {
 		return fmt.Errorf("response body is nil")
 	}
 
+	// Substitute any saved or environment variables in the expected value
+	value = replaceVars(value)
+
 	var response map[string]interface{}
 	if err := json.Unmarshal(body, &response); err != nil {
 		return fmt.Errorf("failed to parse JSON response: %v", err)


### PR DESCRIPTION
## Summary
- ensure expected values in integration assertions can reference env vars

## Testing
- `go test -count=1 ./Test/integration -tags=integration` *(fails: Authorization header not provided)*

------
https://chatgpt.com/codex/tasks/task_e_6863fcafc7f88330932fb021cd5ae728