### PR TITLE
Ensure integration scenarios reauthenticate

### DIFF
--- a/Test/integration/steps.go
+++ b/Test/integration/steps.go
@@ -827,6 +827,12 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 		currentScenarioID = generateUUID()
 		scenarioResources = []string{}
 		skipNextTracking = false
+
+		// Ensure we have a valid authentication token for each scenario
+		if token, exists := savedVars["accessToken"]; !exists || token == "" {
+			createTestUserDirectly()
+		}
+
 		return ctx, nil
 	})
 


### PR DESCRIPTION
## Summary
- reauthenticate before running each integration scenario

## Testing
- `go vet ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686402c5e22483309e0b3a31d0f2b65f