### PR TITLE
Fix autonomous resource tracking

### DIFF
--- a/Test/integration/steps.go
+++ b/Test/integration/steps.go
@@ -396,16 +396,17 @@ func iSaveTheJSONResponseKeyAs(key, varName string) error {
 	if strings.HasSuffix(key, "Id") || strings.HasSuffix(key, "ID") || key == "id" {
 		// Determine the resource type based on the context
 		resourceType := "unknown"
-		if strings.Contains(lastRequestPath, "/users") {
-			resourceType = "user"
-		} else if strings.Contains(lastRequestPath, "/medicines") {
-			resourceType = "medicine"
-		} else if strings.Contains(lastRequestPath, "/icd-cie") {
-			resourceType = "icd-cie"
+		// Match more specific paths first to ensure correct resource type
+		if strings.Contains(lastRequestPath, "/roles") {
+			resourceType = "role"
 		} else if strings.Contains(lastRequestPath, "/devices") {
 			resourceType = "device"
-		} else if strings.Contains(lastRequestPath, "/roles") {
-			resourceType = "role"
+		} else if strings.Contains(lastRequestPath, "/icd-cie") {
+			resourceType = "icd-cie"
+		} else if strings.Contains(lastRequestPath, "/medicines") {
+			resourceType = "medicine"
+		} else if strings.Contains(lastRequestPath, "/users") {
+			resourceType = "user"
 		}
 
 		if resourceType != "unknown" {


### PR DESCRIPTION
## Summary
- fix detection order for autonomous resource tracking so roles and devices cleanup correctly

## Testing
- `bash scripts/run-integration-test.bash -v -f users.feature` *(fails: missing env vars)*

------
https://chatgpt.com/codex/tasks/task_e_686409f651a08330bbf2d3e2a5df0062