### PR TITLE
Fix medicine handler for partial updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,10 @@ uploads/
 
 archives/tmp/
 ia-boilerplate-go
-
+device_service
 build-local.sh
 proyect-content.txt
 
 IA-Driver
 dev-aceso
+ia-boilerplate

--- a/src/repository/entities.go
+++ b/src/repository/entities.go
@@ -55,12 +55,13 @@ type ICDCie struct {
 
 type Medicine struct {
 	ID               int       `gorm:"primaryKey" json:"id"`
-	EANCode          string    `gorm:"type:varchar(30)" json:"eanCode"`
+	EANCode          string    `gorm:"type:varchar(30);unique" json:"eanCode"`
 	Description      string    `gorm:"type:varchar(150)" json:"description"`
 	Type             string    `gorm:"type:varchar(50)" json:"type"`
 	Laboratory       string    `gorm:"type:varchar(50)" json:"laboratory"`
 	IVA              string    `gorm:"type:varchar(5)" json:"iva"`
 	SatKey           string    `gorm:"type:varchar(50)" json:"satKey"`
+	TemperatureCtrl  string    `gorm:"type:varchar(50)" json:"temperatureControl"`
 	ActiveIngredient string    `gorm:"type:varchar(150)" json:"activeIngredient"`
 	CreatedAt        time.Time `gorm:"autoCreateTime" json:"createdAt"`
 	UpdatedAt        time.Time `gorm:"autoUpdateTime" json:"updatedAt"`


### PR DESCRIPTION
## Summary
- allow unique EAN codes and add temperature control to medicine entity
- validate fields and support partial updates in medicine handler
- return proper conflict errors on duplicate EAN codes
- tweak invalid property response message
- ignore compiled binaries

## Testing
- `go test ./...` *(fails: module lookup disabled)*
- `bash scripts/run-integration-test.bash -f medicine.feature` *(fails: `lsof` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68640e581b0483309c6d09246357437a