### PR TITLE
Fix duplicate EAN code creation

### DIFF
--- a/src/handlers/medicine.go
+++ b/src/handlers/medicine.go
@@ -72,7 +72,7 @@ func (h *Handler) CreateMedicine(c *gin.Context) {
 	}
 
 	var existing repository.Medicine
-	if err := h.Repository.DB.Where("ean_code = ?", req.EANCode).First(&existing).Error; err == nil {
+	if err := h.Repository.DB.Where("ean_code = ? AND is_deleted = ?", req.EANCode, false).First(&existing).Error; err == nil {
 		c.JSON(http.StatusConflict, gin.H{"error": "Could not create medicine: duplicate code"})
 		return
 	} else if !errors.Is(err, gorm.ErrRecordNotFound) {

--- a/src/handlers/medicine.go
+++ b/src/handlers/medicine.go
@@ -71,6 +71,15 @@ func (h *Handler) CreateMedicine(c *gin.Context) {
 		return
 	}
 
+	var existing repository.Medicine
+	if err := h.Repository.DB.Where("ean_code = ?", req.EANCode).First(&existing).Error; err == nil {
+		c.JSON(http.StatusConflict, gin.H{"error": "Could not create medicine: duplicate code"})
+		return
+	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Could not create medicine"})
+		return
+	}
+
 	if !validMedicineTypes[req.Type] {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid medicine type"})
 		return


### PR DESCRIPTION
## Summary
- detect existing medicines with the same EAN code before creating a new record

## Testing
- `go build ./...`
- `go test ./...` *(fails: proxy blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68646d63adf08330bfb29a9682165883